### PR TITLE
Tests: Copied publish_in_test to AE

### DIFF
--- a/client/ayon_aftereffects/addon.py
+++ b/client/ayon_aftereffects/addon.py
@@ -32,6 +32,16 @@ class AfterEffectsAddon(AYONAddon, IHostAddon):
             os.path.join(AFTEREFFECTS_ADDON_ROOT, "hooks")
         ]
 
+    def publish_in_test(self, log, close_plugin_name=None):
+        """Runs publish in an opened host with a context.
+
+        Close Python process at the end.
+        """
+
+        from ayon_aftereffects.api.lib import publish_in_test
+
+        publish_in_test(log, close_plugin_name)
+
 
 def get_launch_script_path():
     return os.path.join(

--- a/client/ayon_aftereffects/api/launch_logic.py
+++ b/client/ayon_aftereffects/api/launch_logic.py
@@ -47,7 +47,7 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
-    if os.environ.get("AYON_IN_TESTS"):
+    if is_in_tests():
         manager = AddonsManager()
         aftereffects_addon = manager["aftereffects"]
 

--- a/client/ayon_aftereffects/api/launch_logic.py
+++ b/client/ayon_aftereffects/api/launch_logic.py
@@ -47,16 +47,15 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
-    if os.environ.get("HEADLESS_PUBLISH"):
+    if os.environ.get("AYON_IN_TESTS"):
         manager = AddonsManager()
-        webpublisher_addon = manager["webpublisher"]
+        aftereffects_addon = manager["aftereffects"]
 
         launcher.execute_in_main_thread(
             functools.partial(
-                webpublisher_addon.headless_publish,
+                aftereffects_addon.publish_in_test,
                 log,
                 "CloseAE",
-                is_in_tests()
             )
         )
 

--- a/client/ayon_aftereffects/api/lib.py
+++ b/client/ayon_aftereffects/api/lib.py
@@ -186,8 +186,6 @@ def publish_in_test(log, close_plugin_name=None):
 
     # Error exit as soon as any error occurs.
     error_format = "Failed {plugin.__name__}: {error} -- {error.traceback}"
-    log.info("here")
-    print("here")
     close_plugin = find_close_plugin(close_plugin_name, log)
 
     for result in pyblish.util.publish_iter():


### PR DESCRIPTION
Previously only in webpublisher addon, which caused unwanted dependency. Now it duplicates code in AE (and also PS), but its just simple code for automatic testing.

2 lib functions could be potentially moved to ayon-pipeline-tests, but that publish_in_test in addon should stay.