### PR TITLE
Remove deprecated ImageIOConfigModel and `ocio_config` settings

### DIFF
--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -3,32 +3,6 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 from ayon_server.settings.validators import ensure_unique_names
 
 
-class ImageIOConfigModel(BaseSettingsModel):
-    """[DEPRECATED] Addon OCIO config settings. Please set the OCIO config
-    path in the Core addon profiles here
-    (ayon+settings://core/imageio/ocio_config_profiles).
-    """
-
-    override_global_config: bool = SettingsField(
-        False,
-        title="Override global OCIO config",
-        description=(
-            "DEPRECATED functionality. Please set the OCIO config path in the "
-            "Core addon profiles here (ayon+settings://core/imageio/"
-            "ocio_config_profiles)."
-        ),
-    )
-    filepath: list[str] = SettingsField(
-        default_factory=list,
-        title="Config path",
-        description=(
-            "DEPRECATED functionality. Please set the OCIO config path in the "
-            "Core addon profiles here (ayon+settings://core/imageio/"
-            "ocio_config_profiles)."
-        ),
-    )
-
-
 class ImageIOFileRuleModel(BaseSettingsModel):
     name: str = SettingsField("", title="Rule name")
     pattern: str = SettingsField("", title="Regex pattern")
@@ -52,10 +26,6 @@ class ImageIOFileRulesModel(BaseSettingsModel):
 class AfterEffectsImageIOModel(BaseSettingsModel):
     activate_host_color_management: bool = SettingsField(
         True, title="Enable Color Management"
-    )
-    ocio_config: ImageIOConfigModel = SettingsField(
-        default_factory=ImageIOConfigModel,
-        title="OCIO config"
     )
     file_rules: ImageIOFileRulesModel = SettingsField(
         default_factory=ImageIOFileRulesModel,


### PR DESCRIPTION
## Changelog Description

Remove deprecated `ocio_config` `ImageIOConfigModel` settings

## Additional info

With [the support of profiles to determine OCIO config in ayon-core](https://github.com/ynput/ayon-core/pull/490) this logic has been superseded and should be removed from each addon still having the deprecated settings.

Related to https://github.com/ynput/ayon-core/issues/785