### PR TITLE
Define app host name

### DIFF
--- a/package.py
+++ b/package.py
@@ -1,9 +1,10 @@
 name = "aftereffects"
 title = "AfterEffects"
 version = "0.2.4-dev.1"
-
+app_host_name = "aftereffects"
 client_dir = "ayon_aftereffects"
 
+ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
     "core": ">0.3.2",
 }


### PR DESCRIPTION
## Changelog Description

* added `app_host_name`
* added `ayon_server_version`

## Additional info

Similar changes and original motivations were discussed for Hiero addon here: https://github.com/ynput/ayon-hiero/pull/8

## Testing notes:

1. Create package
2. Reupload the package as new bundle and enable it in the environment
