### PR TITLE
Bugfix: Removed obsolete method, replaced by standard icon

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -1,6 +1,5 @@
 import re
 
-from ayon_core import resources
 from ayon_core.lib import BoolDef, UISeparatorDef, EnumDef
 from ayon_core.pipeline import (
     Creator,

--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -24,6 +24,7 @@ class RenderCreator(Creator):
     label = "Render"
     product_type = "render"
     description = "Render creator"
+    icon = "eye"
 
     create_allow_context_change = True
 
@@ -148,9 +149,6 @@ class RenderCreator(Creator):
                 default=False
             )
         ]
-
-    def get_icon(self):
-        return resources.get_openpype_splash_filepath()
 
     def collect_instances(self):
         for instance_data in cache_and_get_instances(self):


### PR DESCRIPTION
## Changelog Description
This caused no creators to showing up.


## Additional info
Original function used was recently removed as it was still `openpype`


## Testing notes:

1. open AE
2. start Publisher - `render` product type should show up in middle column
