### PR TITLE
Fix deadline key is dictionary not None

### DIFF
--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -153,7 +153,7 @@ class CollectAERender(publish.AbstractCollectRender):
                 if "review" in instance.families:
                     # to skip ExtractReview locally
                     instance.families.remove("review")
-                instance.deadline = inst.data.get("deadline")
+                instance.deadline = inst.data.get("deadline", {})
 
             instances.append(instance)
 

--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -153,7 +153,6 @@ class CollectAERender(publish.AbstractCollectRender):
                 if "review" in instance.families:
                     # to skip ExtractReview locally
                     instance.families.remove("review")
-                instance.deadline = inst.data.get("deadline", {})
 
             instances.append(instance)
 


### PR DESCRIPTION
## Changelog Description
It is expected that 'deadline' will be empty dictionary or won't be at all, not None.

## Additional review information
Fixes issue later in `collect_deadline_server_from_instance` where it looks for presence of `deadline` key.
