### PR TITLE
Chore: Remove usage of 'six'

### DIFF
--- a/client/ayon_aftereffects/api/plugin.py
+++ b/client/ayon_aftereffects/api/plugin.py
@@ -1,11 +1,8 @@
-import six
-from abc import ABCMeta
-
 from ayon_core.pipeline import LoaderPlugin
+
 from .launch_logic import get_stub
 
 
-@six.add_metaclass(ABCMeta)
 class AfterEffectsLoader(LoaderPlugin):
     @staticmethod
     def get_stub():


### PR DESCRIPTION
## Changelog Description
Removed usage of `six`.
