### PR TITLE
Improve logging: Do not log AEItem in artist facing report, plus report item with debug log for could not find layer metadata

### DIFF
--- a/client/ayon_aftereffects/api/ws_stub.py
+++ b/client/ayon_aftereffects/api/ws_stub.py
@@ -121,7 +121,7 @@ class AfterEffectsServerStub():
                     str(item.id) == str(item_meta.get('members')[0]):
                 return item_meta
 
-        self.log.debug("Couldn't find layer metadata")
+        self.log.debug(f"Couldn't find layer metadata for item: {item}")
 
     def imprint(self, item_id, data, all_items=None, items_meta=None):
         """

--- a/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
+++ b/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
@@ -37,6 +37,7 @@ class ValidateFootageItems(pyblish.api.InstancePlugin):
         comp_id = instance.data["comp_id"]
         for footage_item in get_stub().get_items(
                 comps=False, folders=False, footages=True):
+            self.log.debug(f"Validating footage item: {footage_item.name}")
             if comp_id not in footage_item.containing_comps:
                 continue
 

--- a/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
+++ b/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
@@ -37,7 +37,7 @@ class ValidateFootageItems(pyblish.api.InstancePlugin):
         comp_id = instance.data["comp_id"]
         for footage_item in get_stub().get_items(comps=False, folders=False,
                                                  footages=True):
-            self.log.info(footage_item)
+            self.log.debug(f"Validating footage item: {footage_item}")
             if comp_id not in footage_item.containing_comps:
                 continue
 

--- a/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
+++ b/client/ayon_aftereffects/plugins/publish/validate_footage_items.py
@@ -35,9 +35,8 @@ class ValidateFootageItems(pyblish.api.InstancePlugin):
         """Plugin entry point."""
 
         comp_id = instance.data["comp_id"]
-        for footage_item in get_stub().get_items(comps=False, folders=False,
-                                                 footages=True):
-            self.log.debug(f"Validating footage item: {footage_item}")
+        for footage_item in get_stub().get_items(
+                comps=False, folders=False, footages=True):
             if comp_id not in footage_item.containing_comps:
                 continue
 
@@ -45,5 +44,5 @@ class ValidateFootageItems(pyblish.api.InstancePlugin):
             if path and not os.path.exists(path):
                 msg = f"File {path} not found."
                 formatting = {"name": footage_item.name, "path": path}
-                raise PublishXmlValidationError(self, msg,
-                                                formatting_data=formatting)
+                raise PublishXmlValidationError(
+                    self, msg, formatting_data=formatting)


### PR DESCRIPTION
## Changelog Description

Improve logging: Do not log AEItem in artist facing report, plus report item with debug log for could not find layer metadata

## Additional review information

Cosmetics mostly.

## Testing notes:

1. Publish an after effects comp.
2. Artist-facing publish log should not be heavily polluted with `AEItem` log.
3. Logs in Details tab should be clearer for all `Couldn't find layer metadata' logs because it now mentions the item it failed for - which may help identify any issues.