### PR TITLE
Refactor `CollectWorkfile` to InstancePlugin

### DIFF
--- a/client/ayon_aftereffects/plugins/publish/collect_workfile.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_workfile.py
@@ -3,31 +3,20 @@ import os
 import pyblish.api
 
 
-class CollectWorkfile(pyblish.api.ContextPlugin):
-    """ Adds the AE render instances """
+class CollectWorkfile(pyblish.api.InstancePlugin):
+    """Collect Workfile representation."""
 
-    label = "Collect After Effects Workfile Instance"
+    label = "Collect After Effects Workfile"
     order = pyblish.api.CollectorOrder + 0.1
+    families = ["workfile"]
 
-    default_variant = "Main"
-
-    def process(self, context):
-        workfile_instance = None
-        for instance in context:
-            if instance.data["productType"] == "workfile":
-                self.log.debug("Workfile instance found")
-                workfile_instance = instance
-                break
-
-        current_file = context.data["currentFile"]
+    def process(self, instance):
+        current_file = instance.context.data["currentFile"]
         staging_dir = os.path.dirname(current_file)
         scene_file = os.path.basename(current_file)
-        if workfile_instance is None:
-            self.log.debug("Workfile instance not found. Skipping")
-            return
 
         # creating representation
-        workfile_instance.data["representations"].append({
+        instance.data.setdefault("representations", []).append({
             "name": "aep",
             "ext": "aep",
             "files": scene_file,


### PR DESCRIPTION
## Changelog Description

Refactor `CollectWorkfile` to InstancePlugin, it doesn't need to be ContextPlugin

## Additional review information

...

## Testing notes:
1. Publishing workfile should still work