### PR TITLE
Workfile Builder: Template settings key `template_path` -> `path`

### DIFF
--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -28,6 +28,7 @@ class TemplatedWorkfileProfileModel(BaseSettingsModel):
 
 
 class TemplatedWorkfileBuildModel(BaseSettingsModel):
+    """More complex workfile template builder with Placeholders"""
     profiles: list[TemplatedWorkfileProfileModel] = SettingsField(
         default_factory=list
     )

--- a/server/settings/templated_workfile_build.py
+++ b/server/settings/templated_workfile_build.py
@@ -28,7 +28,7 @@ class TemplatedWorkfileProfileModel(BaseSettingsModel):
 
 
 class TemplatedWorkfileBuildModel(BaseSettingsModel):
-    """More complex workfile template builder with Placeholders"""
+    """Workfile template builder with dynamic items via Placeholders"""
     profiles: list[TemplatedWorkfileProfileModel] = SettingsField(
         default_factory=list
     )

--- a/server/settings/workfile_builder.py
+++ b/server/settings/workfile_builder.py
@@ -16,10 +16,12 @@ class CustomBuilderTemplate(BaseSettingsModel):
 
 
 class WorkfileBuilderPlugin(BaseSettingsModel):
+    """Legacy use of simple workfile template based on Task type"""
     _title = "Workfile Builder"
     create_first_version: bool = SettingsField(
         False,
-        title="Create first workfile"
+        title="Create first workfile",
+        description="Must be enabled to copy template and create first workfile"
     )
 
     custom_templates: list[CustomBuilderTemplate] = SettingsField(

--- a/server/settings/workfile_builder.py
+++ b/server/settings/workfile_builder.py
@@ -16,12 +16,13 @@ class CustomBuilderTemplate(BaseSettingsModel):
 
 
 class WorkfileBuilderPlugin(BaseSettingsModel):
-    """Legacy use of simple workfile template based on Task type"""
+    """Simpler workfile template based on Task type"""
     _title = "Workfile Builder"
     create_first_version: bool = SettingsField(
         False,
         title="Create first workfile",
-        description="Must be enabled to copy template and create first workfile"
+        description="Save first workfile with the built template on "
+                    "first run if no existing workfile exists."
     )
 
     custom_templates: list[CustomBuilderTemplate] = SettingsField(

--- a/server/settings/workfile_builder.py
+++ b/server/settings/workfile_builder.py
@@ -10,7 +10,7 @@ class CustomBuilderTemplate(BaseSettingsModel):
         default_factory=list,
         title="Task types",
     )
-    template_path: MultiplatformPathModel = SettingsField(
+    path: MultiplatformPathModel = SettingsField(
         default_factory=MultiplatformPathModel
     )
 


### PR DESCRIPTION
## Changelog Description

Fix After Effects unable to load a template in the launcher and not opening because of wrong key.

## Additional review information

Fix: https://github.com/ynput/ayon-aftereffects/issues/6

See: https://github.com/ynput/ayon-core/pull/1202

This implements the fix in `ayon-aftereffects` instead of `ayon-core` so that it fixes this integration, instead of changing it in core which would break all other integrations.

I didn't bother implementing setting conversions - because it was broken before anyway.

## Testing notes:

1. Workfile templates should work
