### PR TITLE
Create Render: Do not enforce renaming of composition (defined by settings now) + allow multiple comps to target same product name

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -84,11 +84,6 @@ class RenderCreator(Creator):
                     flags=re.IGNORECASE
                 )
 
-            for inst in self.create_context.instances:
-                if comp_product_name == inst.product_name:
-                    raise CreatorError("{} already exists".format(
-                        inst.product_name))
-
             data["members"] = [comp.id]
             data["orig_comp_name"] = composition_name
 

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -9,6 +9,14 @@ class CreateRenderPlugin(BaseSettingsModel):
     )
     force_setting_values: bool = SettingsField(
         True, title="Force resolution and duration values from Folder")
+    rename_comp_to_product_name: bool = SettingsField(
+        True,
+        title="Rename composition to product name",
+        description=(
+            "Rename composition to product name when creating render instance "
+            "or when updating product name, e.g. on variant change."
+        )
+    )
 
 
 class AfterEffectsCreatorPlugins(BaseSettingsModel):

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -43,6 +43,8 @@ DEFAULT_AFTEREFFECTS_SETTING = {
         "RenderCreator": {
             "mark_for_review": True,
             "default_variants": ["Main"],
+            "force_setting_values": True,
+            "rename_comp_to_product_name": True,
         }
     },
     "publish": AE_PUBLISH_PLUGINS_DEFAULTS,


### PR DESCRIPTION
## Changelog Description

- Create Render: Do not enforce renaming of composition (defined by settings now) 
- Allow multiple comps to target same product name, since that is totally fine when targeting e.g. another folder.
- + minor cosmetics to move transfer to `creator_attributes` out of for loop because data remains the same.

## Additional review information

...

## Testing notes:

1. Create render instance should work
2. Changing setting should indeed influence the renaming behavior.
