### PR TITLE
Create Render: Set Comp settings based on task entity attributes instead of folder

### DIFF
--- a/client/ayon_aftereffects/api/__init__.py
+++ b/client/ayon_aftereffects/api/__init__.py
@@ -17,7 +17,7 @@ from .pipeline import (
 from .lib import (
     maintained_selection,
     get_extension_manifest_path,
-    get_folder_settings,
+    get_entity_attributes,
     set_settings
 )
 
@@ -38,7 +38,7 @@ __all__ = [
     # lib
     "maintained_selection",
     "get_extension_manifest_path",
-    "get_folder_settings",
+    "get_entity_attributes",
     "set_settings",
 
     # plugin

--- a/client/ayon_aftereffects/api/lib.py
+++ b/client/ayon_aftereffects/api/lib.py
@@ -7,8 +7,6 @@ import logging
 import pyblish
 from typing import Union
 
-import ayon_api
-
 from ayon_core.pipeline.context_tools import get_current_task_entity
 
 from .ws_stub import get_stub

--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -111,7 +111,24 @@ class RenderCreator(Creator):
 
             stub.rename_item(comp.id, comp_product_name)
             if self.force_setting_values:
-                set_settings(True, True, [comp.id], print_msg=False)
+                # Force fps, frame range and resolution of comp to match
+                # the target publish context attributes.
+                # Task is not required for an instance, so it may be not set
+                if data.get("task"):
+                    entity = self.create_context.get_task_entity(
+                        folder_path=data["folderPath"],
+                        task_name=data["task"]
+                    )
+                else:
+                    entity = self.create_context.get_folder_entity(
+                        folder_path=data["folderPath"]
+                    )
+                set_settings(
+                    frames=True,
+                    resolution=True,
+                    comp_ids=[comp.id],
+                    print_msg=False,
+                    entity=entity)
 
     def get_pre_create_attr_defs(self):
         output = [

--- a/client/ayon_aftereffects/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_aftereffects/plugins/publish/validate_scene_settings.py
@@ -122,7 +122,7 @@ class ValidateSceneSettings(OptionalPyblishPluginMixin,
             "resolutionHeight": instance.data.get("resolutionHeight"),
             "duration": duration
         }
-        self.log.debug("Comp attributes: {}".format(current_settings))
+        self.log.debug(f"Comp attributes: {current_settings}")
 
         invalid_settings = []
         invalid_keys = set()
@@ -132,9 +132,11 @@ class ValidateSceneSettings(OptionalPyblishPluginMixin,
                     key, value, current_settings[key])
 
                 if key == "duration" and expected_settings.get("handleStart"):
-                    msg += "Handles included in calculation. Remove " \
-                           "handles in DB or extend frame range in " \
-                           "Composition Setting."
+                    msg += (
+                        "Handles included in calculation. Remove "
+                        "handles in DB or extend frame range in "
+                        "Composition Setting."
+                    )
 
                 invalid_settings.append(msg)
                 invalid_keys.add(key)


### PR DESCRIPTION
## Changelog Description

Set and validate comp settings (frame range, fps and resolution) based on task entity attributes instead of folder entity attributes

## Additional review information

Plus some cosmetic changes, like mentioning less of Ftrack and refer to just the AYON attributes + type hints.

Also, note that this now would validate against the instance attributes (resolution, fps, frame range) of the **target** folder and task to be published to and does not enforce the current context's attributes. That can be useful when publishing to e.g. different shots from one After Effects project.

## Testing notes:

1. Creating render instance with forcing default settings should work, it should adhere to task entity attribute overrides.
2. Validation for frame range, fps and resolution should work (and should use the frame range, etc. of target entity context.