### PR TITLE
Reduce legacy terminology

### DIFF
--- a/client/ayon_aftereffects/api/README.md
+++ b/client/ayon_aftereffects/api/README.md
@@ -2,11 +2,11 @@
 
 Requirements: This extension requires use of Javascript engine, which is
 available since CC 16.0.
-Please check your File>Project Settings>Expressions>Expressions Engine
+Please check your `File > Project Settings > Expressions > Expressions Engine`
 
 ## Setup
 
-The After Effects integration requires two components to work; `extension` and `server`.
+The After Effects integration requires two components to work: `extension` and `server`.
 
 ### Extension
 
@@ -20,22 +20,11 @@ download [Anastasiy’s Extension Manager](https://install.anastasiy.com/)
 
 `{path to addon}` will be most likely in your AppData (on Windows, in your user data folder in Linux and MacOS.)
 
-### Server
-
-The easiest way to get the server and After Effects launch is with:
-
-```
-python -c ^"import ayon_core.hosts.photoshop;ayon_aftereffects.launch(""c:\Program Files\Adobe\Adobe After Effects 2020\Support Files\AfterFX.exe"")^"
-```
-
-`avalon.aftereffects.launch` launches the application and server, and also closes the server when After Effects exists.
-
 ## Usage
 
 The After Effects extension can be found under `Window > Extensions > AYON`. Once launched you should be presented with a panel like this:
 
 ![Ayon Panel](panel.png "Ayon Panel")
-
 
 ## Developing
 
@@ -51,17 +40,17 @@ ZXPSignCmd -sign {path to addon}/api/extension {path to addon}/api/extension.zxp
 
 ### Plugin Examples
 
-These plugins were made with the [polly config](https://github.com/mindbender-studio/config). To fully integrate and load, you will have to use this config and add `image` to the [integration plugin](https://github.com/mindbender-studio/config/blob/master/polly/plugins/publish/integrate_asset.py).
-
 Expected deployed extension location on default Windows:
-`c:\Program Files (x86)\Common Files\Adobe\CEP\extensions\io.ynput.AE.panel`
+`C:\Program Files (x86)\Common Files\Adobe\CEP\extensions\io.ynput.AE.panel`
 
 For easier debugging of Javascript:
 https://community.adobe.com/t5/download-install/adobe-extension-debuger-problem/td-p/10911704?page=1
-Add (optional) --enable-blink-features=ShadowDOMV0,CustomElementsV0 when starting Chrome
-then localhost:8092
+
+1. Add (optional) `--enable-blink-features=ShadowDOMV0,CustomElementsV0` when starting Chrome
+2. Then go to `localhost:8092`
 
 Or use Visual Studio Code https://medium.com/adobetech/extendscript-debugger-for-visual-studio-code-public-release-a2ff6161fa01
+
 ## Resources
   - https://javascript-tools-guide.readthedocs.io/introduction/index.html
   - https://github.com/Adobe-CEP/Getting-Started-guides

--- a/client/ayon_aftereffects/api/extension/jsx/hostscript.jsx
+++ b/client/ayon_aftereffects/api/extension/jsx/hostscript.jsx
@@ -429,7 +429,7 @@ function getCompProperties(comp_id){
 function setCompProperties(comp_id, frameStart, framesCount, frameRate,
                            width, height){
     /**
-     * Sets work area info from outside (from Ftrack via OpenPype)
+     * Sets work area info from outside (usually from AYON entity attributes)
      */
     var comp = app.project.itemByID(comp_id);
     if (!comp){

--- a/client/ayon_aftereffects/api/launch_logic.py
+++ b/client/ayon_aftereffects/api/launch_logic.py
@@ -47,6 +47,12 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
+    workfiles_on_launch = os.getenv(
+        "AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH",
+        # Backwards compatibility
+        os.getenv("AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH", True)
+    )
+
     if is_in_tests():
         manager = AddonsManager()
         aftereffects_addon = manager["aftereffects"]
@@ -59,7 +65,7 @@ def main(*subprocess_args):
             )
         )
 
-    elif os.environ.get("AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH", True):
+    elif workfiles_on_launch:
         save = False
         if os.getenv("WORKFILES_SAVE_AS"):
             save = True

--- a/client/ayon_aftereffects/api/pipeline.py
+++ b/client/ayon_aftereffects/api/pipeline.py
@@ -9,7 +9,7 @@ from ayon_core.pipeline import (
     register_loader_plugin_path,
     register_creator_plugin_path,
     register_workfile_build_plugin_path,
-    AVALON_CONTAINER_ID,
+    AYON_CONTAINER_ID,
     AVALON_INSTANCE_ID,
     AYON_INSTANCE_ID,
 )
@@ -256,7 +256,7 @@ def containerise(name,
     """
     data = {
         "schema": "ayon:container-3.0",
-        "id": AVALON_CONTAINER_ID,
+        "id": AYON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
         "loader": str(loader),

--- a/client/ayon_aftereffects/api/pipeline.py
+++ b/client/ayon_aftereffects/api/pipeline.py
@@ -120,7 +120,7 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         Pulls from File > File Info
 
-        For SubsetManager
+        For Scene Inventory (Manage...)
 
         Returns:
             (list) of dictionaries matching instances format
@@ -145,10 +145,10 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         Updates metadata of current file in File > File Info and removes
         icon highlight on group layer.
 
-        For SubsetManager
+        For Scene Inventory
 
         Args:
-            instance (dict): instance representation from subsetmanager model
+            instance (dict): instance representation from Scene Inventory model
         """
         stub = self.stub
 

--- a/client/ayon_aftereffects/api/pipeline.py
+++ b/client/ayon_aftereffects/api/pipeline.py
@@ -63,7 +63,7 @@ class AfterEffectsHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return self._stub
 
     def install(self):
-        print("Installing Pype config...")
+        print("Installing AYON After Effects integration...")
 
         pyblish.api.register_host("aftereffects")
         pyblish.api.register_plugin_path(PUBLISH_PATH)
@@ -255,7 +255,7 @@ def containerise(name,
         container (str): Name of container assembly
     """
     data = {
-        "schema": "openpype:container-2.0",
+        "schema": "ayon:container-3.0",
         "id": AVALON_CONTAINER_ID,
         "name": name,
         "namespace": namespace,
@@ -279,7 +279,7 @@ def cache_and_get_instances(creator):
     Returns:
         List[]: list of all instances stored in metadata
     """
-    shared_key = "openpype.photoshop.instances"
+    shared_key = "ayon.aftereffects.instances"
     if shared_key not in creator.collection_shared_data:
         creator.collection_shared_data[shared_key] = \
             creator.host.list_instances()

--- a/client/ayon_aftereffects/api/workfile_template_builder.py
+++ b/client/ayon_aftereffects/api/workfile_template_builder.py
@@ -15,7 +15,7 @@ from ayon_core.pipeline.workfile.workfile_template_builder import (
 from ayon_aftereffects.api import get_stub
 
 PLACEHOLDER_SET = "PLACEHOLDERS_SET"
-PLACEHOLDER_ID = "openpype.placeholder"
+PLACEHOLDER_ID = "ayon.placeholder"
 
 
 class AETemplateBuilder(AbstractTemplateBuilder):
@@ -115,7 +115,7 @@ class AEPlaceholderPlugin(PlaceholderPlugin):
         if not item_id:
             raise ValueError("Couldn't create a placeholder")
         container_data = {
-            "id": "openpype.placeholder",
+            "id": PLACEHOLDER_ID,
             "name": name,
             "is_placeholder": True,
             "plugin_identifier": self.identifier,

--- a/client/ayon_aftereffects/api/ws_stub.py
+++ b/client/ayon_aftereffects/api/ws_stub.py
@@ -44,11 +44,11 @@ class AEItem(object):
 
 
 class AfterEffectsServerStub():
-    """
-        Stub for calling function on client (Photoshop js) side.
-        Expects that client is already connected (started when avalon menu
-        is opened).
-        'self.websocketserver.call' is used as async wrapper
+    """Stub for calling function on client (After Effects js) side.
+
+    Expects that client is already connected (started when AYON menu is opened)
+
+    'self.websocketserver.call' is used as async wrapper
     """
     PUBLISH_ICON = '\u2117 '
     LOADED_ICON = '\u25bc'
@@ -722,7 +722,7 @@ def get_stub():
         Convenience function to get server RPC stub to call methods directed
         for host (Photoshop).
         It expects already created connection, started from client.
-        Currently created when panel is opened (PS: Window>Extensions>Avalon)
+        Currently, created when panel is opened (PS: Window>Extensions>AYON)
     :return: <PhotoshopClientStub> where functions could be called from
     """
     ae_stub = AfterEffectsServerStub()

--- a/client/ayon_aftereffects/plugins/load/load_background.py
+++ b/client/ayon_aftereffects/plugins/load/load_background.py
@@ -57,7 +57,6 @@ class BackgroundLoader(api.AfterEffectsLoader):
         )
 
     def update(self, container, context):
-        """ Switch asset or change version """
         stub = self.get_stub()
         folder_name = context["folder"]["name"]
         product_name = context["product"]["name"]

--- a/client/ayon_aftereffects/plugins/load/load_file.py
+++ b/client/ayon_aftereffects/plugins/load/load_file.py
@@ -8,7 +8,7 @@ from ayon_aftereffects.api.lib import get_unique_layer_name
 class FileLoader(api.AfterEffectsLoader):
     """Load images
 
-    Stores the imported asset in a container named after the asset.
+    Stores the imported product version in a container named after the folder.
     """
     label = "Load file"
 
@@ -72,7 +72,6 @@ class FileLoader(api.AfterEffectsLoader):
         )
 
     def update(self, container, context):
-        """ Switch asset or change version """
         stub = self.get_stub()
         layer = container.pop("layer")
 
@@ -83,7 +82,7 @@ class FileLoader(api.AfterEffectsLoader):
         namespace_from_container = re.sub(r'_\d{3}$', '',
                                           container["namespace"])
         layer_name = "{}_{}".format(folder_name, product_name)
-        # switching assets
+        #
         if namespace_from_container != layer_name:
             layers = stub.get_items(comps=True)
             existing_layers = [layer.name for layer in layers]

--- a/client/ayon_aftereffects/plugins/publish/collect_extension_version.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_extension_version.py
@@ -9,15 +9,15 @@ from ayon_aftereffects.api import (
 
 
 class CollectExtensionVersion(pyblish.api.ContextPlugin):
-    """ Pulls and compares version of installed extension.
+    """Pulls and compares version of installed extension.
 
-        It is recommended to use same extension as in provided Openpype code.
+    It is recommended to use same extension as in provided AYON code.
 
-        Please use Anastasiy’s Extension Manager or ZXPInstaller to update
-        extension in case of an error.
+    Please use Anastasiy’s Extension Manager or ZXPInstaller to update
+    extension in case of an error.
 
-        You can locate extension.zxp in your installed Openpype code in
-        `repos/avalon-core/avalon/aftereffects`
+    You can locate extension.zxp in your installed AYON After Effects code
+    in `repos/ayon-aftereffects/api/extension.zxp`.
     """
     # This technically should be a validator, but other collectors might be
     # impacted with usage of obsolete extension, so collector that runs first

--- a/client/ayon_aftereffects/plugins/publish/validate_scene_settings.py
+++ b/client/ayon_aftereffects/plugins/publish/validate_scene_settings.py
@@ -30,8 +30,7 @@ class ValidateSceneSettings(OptionalPyblishPluginMixin,
 
         If this complains:
             Check error message where is discrepancy.
-            Check FTrack task 'pype' section of task attributes for expected
-            values.
+            Check AYON section of task attributes for expected values.
             Check/modify rendered Composition Settings.
 
         If you know what you are doing run publishing again, uncheck this

--- a/client/ayon_aftereffects/plugins/workfile_build/load_placeholder.py
+++ b/client/ayon_aftereffects/plugins/workfile_build/load_placeholder.py
@@ -32,7 +32,7 @@ class AEPlaceholderLoadPlugin(wtb.AEPlaceholderPlugin, PlaceholderLoadMixin):
         self._imprint_item(item_id, name, placeholder_data, stub)
 
     def populate_placeholder(self, placeholder):
-        """Use Openpype Loader from `placeholder` to create new FootageItems
+        """Use AYON Loader from `placeholder` to create new FootageItems
 
         New FootageItems are created, files are imported.
         """


### PR DESCRIPTION
## Changelog Description

Remove mentions of things like "subset" or "asset" or even older "openpype", "pype", "avalon" and "polly".

## Additional review information

Now also supports `AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH` instead of `AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH` which we can then start updating in `ayon-applications` defaults:

https://github.com/ynput/ayon-applications/blob/e15be5ab9e634217c23742b5320792734a9c0ab0/server/applications.json#L932

Should fix: https://github.com/ynput/ayon-aftereffects/issues/10

## Testing notes:

1. Proofread
2. After Effects integration should still work and run fine.
