### PR TITLE
Create Render: Fix applying setting `force_setting_values`

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -220,6 +220,9 @@ class RenderCreator(Creator):
         self.rename_comp_to_product_name = plugin_settings.get(
             "rename_comp_to_product_name", self.rename_comp_to_product_name
         )
+        self.force_setting_values = plugin_settings.get(
+            "force_setting_values", self.force_setting_values
+        )
 
     def get_detail_description(self):
         return """Creator for Render instances

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -8,7 +8,7 @@ class CreateRenderPlugin(BaseSettingsModel):
         title="Default Variants"
     )
     force_setting_values: bool = SettingsField(
-        True, title="Force resolution and duration values from Folder")
+        True, title="Force resolution and duration values from Task")
     rename_comp_to_product_name: bool = SettingsField(
         True,
         title="Rename composition to product name",


### PR DESCRIPTION
## Changelog Description

Apply `ayon+settings://aftereffects/create/RenderCreator/force_setting_values` setting to Render Creator

## Additional review information

Disabling the setting should now work.
Apparently the setting was not applied?

## Testing notes:

1. Disabling the setting should now work.
