### PR TITLE
Auto install on Mac

### DIFF
--- a/client/ayon_aftereffects/hooks/pre_launch_install_ayon_extension.py
+++ b/client/ayon_aftereffects/hooks/pre_launch_install_ayon_extension.py
@@ -69,11 +69,11 @@ class InstallAyonExtensionToAfterEffect(PreLaunchHook):
                 archive.extractall(path=target_path)
             self.log.info("Successfully installed AYON extension")
 
-        except OSError as error:
-            self.log.warning(f"OS error has occurred: {error}")
-
         except PermissionError as error:
             self.log.warning(f"Permissions error has occurred: {error}")
+
+        except OSError as error:
+            self.log.warning(f"OS error has occurred: {error}")
 
         except Exception as error:
             self.log.warning(f"An unexpected error occurred: {error}")

--- a/client/ayon_aftereffects/hooks/pre_launch_install_ayon_extension.py
+++ b/client/ayon_aftereffects/hooks/pre_launch_install_ayon_extension.py
@@ -1,9 +1,8 @@
-import os
-import platform
+from pathlib import Path
 from zipfile import ZipFile
 import xml.etree.ElementTree as ET
 from shutil import rmtree
-
+import platformdirs
 
 from ayon_aftereffects import AFTEREFFECTS_ADDON_ROOT
 from ayon_applications import PreLaunchHook, LaunchTypes
@@ -39,27 +38,20 @@ class InstallAyonExtensionToAfterEffect(PreLaunchHook):
     def inner_execute(self):
         self.log.info("Installing AYON After Effects extension.")
 
-        # Windows only for now.
-        if not platform.system().lower() == "windows":
-            self.log.info("Non Windows platform. Cancelling..")
-            return
-
-        target_path = os.path.join(
-            os.environ["appdata"],
-            "Adobe",
-            "CEP",
-            "extensions",
-            "io.ynput.AE.panel",
+        target_path = Path(
+            # roaming is applicable for windows
+            platformdirs.user_data_dir(roaming=True),
+            "Adobe/CEP/extensions/io.ynput.AE.panel"
         )
 
-        extension_path = os.path.join(
+        extension_path = Path(
             AFTEREFFECTS_ADDON_ROOT,
             "api",
             "extension.zxp",
         )
 
         # Extension already installed, compare the versions
-        if os.path.exists(target_path):
+        if target_path.is_dir():
             self.log.info(
                 f"The extension already exists at: {target_path}. "
                 f"Comparing versions.."
@@ -69,54 +61,89 @@ class InstallAyonExtensionToAfterEffect(PreLaunchHook):
             ):
                 return
 
-        self.log.debug(f"Creating directory: {target_path}")
-        os.makedirs(target_path, exist_ok=True)
+        try:
+            self.log.debug(f"Creating directory: {target_path}")
+            target_path.mkdir(parents=True, exist_ok=True)
 
-        with ZipFile(extension_path, "r") as archive:
-            archive.extractall(path=target_path)
+            with ZipFile(extension_path, "r") as archive:
+                archive.extractall(path=target_path)
+            self.log.info("Successfully installed AYON extension")
 
-        self.log.info("Successfully installed AYON extension")
+        except OSError as error:
+            self.log.warning(f"OS error has occurred: {error}")
+
+        except PermissionError as error:
+            self.log.warning(f"Permissions error has occurred: {error}")
+
+        except Exception as error:
+            self.log.warning(f"An unexpected error occurred: {error}")
 
     def _compare_extension_versions(
-        self, target_path: str, extension_path: str
+        self, target_path: Path, extension_path: Path
     ) -> bool:
-        # opens the existing extension manifest to get the Version attr
-        with open(f"{target_path}/CSXS/manifest.xml", "rb") as xml_file:
-            installed_version = (
-                ET.parse(xml_file)
-                .getroot()
-                .attrib.get("ExtensionBundleVersion")
+        try:
+            # opens the existing extension manifest to get the Version attr
+            with target_path.joinpath("CSXS", "manifest.xml").open("rb") as xml_file:
+                installed_version = (
+                    ET.parse(xml_file)
+                    .getroot()
+                    .attrib.get("ExtensionBundleVersion")
+                )
+            self.log.debug(
+                f"Current extension version found: {installed_version}"
             )
-        self.log.debug(f"Current extension version found: {installed_version}")
 
-        if not installed_version:
+            if not installed_version:
+                self.log.warning(
+                    "Unable to resolve the currently installed extension "
+                    "version. Cancelling.."
+                )
+                return False
+
+            # opens the .zxp manifest to get the Version attribute.
+            with ZipFile(extension_path, "r") as archive:
+                xml_file = archive.open("CSXS/manifest.xml")
+                new_version = (
+                    ET.parse(xml_file)
+                    .getroot()
+                    .attrib.get("ExtensionBundleVersion")
+                )
+                if not new_version:
+                    self.log.warning(
+                        "Unable to resolve the new extension version. "
+                        "Cancelling.."
+                    )
+                self.log.debug(f"New extension version found: {new_version}")
+
+                # compare the two versions, a simple == is enough since
+                # we don't care if the version increments or decrements
+                # if they match nothing happens.
+                if installed_version == new_version:
+                    self.log.info("Versions matched. Cancelling..")
+                    return False
+
+                # remove the existing addon
+                self.log.info(
+                    "Version mismatch found. Removing old extensions.."
+                )
+                rmtree(target_path)
+                return True
+
+        except PermissionError as error:
             self.log.warning(
-                "Unable to resolve the currently installed extension "
-                "version. Cancelling.."
+                "Permissions error has occurred while comparing "
+                f"versions: {error}"
             )
             return False
 
-        # opens the .zxp manifest to get the Version attribute.
-        with ZipFile(extension_path, "r") as archive:
-            xml_file = archive.open("CSXS/manifest.xml")
-
-        new_version = (
-            ET.parse(xml_file).getroot().attrib.get("ExtensionBundleVersion")
-        )
-        if not new_version:
+        except OSError as error:
             self.log.warning(
-                "Unable to resolve the new extension version. " "Cancelling.."
+                f"OS error has occurred while comparing versions: {error}"
             )
-        self.log.debug(f"New extension version found: {new_version}")
-
-        # compare the two versions, a simple == is enough since
-        # we don't care if the version increments or decrements
-        # if they match nothing happens.
-        if installed_version == new_version:
-            self.log.info("Versions matched. Cancelling..")
             return False
 
-        # remove the existing addon
-        self.log.info("Version mismatch found. Removing old extensions..")
-        rmtree(target_path)
-        return True
+        except Exception as error:
+            self.log.warning(
+                f"An unexpected error occurred when comparing version: {error}"
+            )
+            return False


### PR DESCRIPTION
## Changelog Description
This allows to run `auto_install` not only on Windows, but on Mac also.

## Testing notes:
1. remove deployed extension in `appData` if necessary
`c:\YOURUSER\petrk\AppData\Roaming\Adobe\CEP\extensions\io.ynput.AE.panel`
2. start PS
3. check if installed