### PR TITLE
Support multiple running After Effects instances at the same time

### DIFF
--- a/client/ayon_aftereffects/api/webserver.py
+++ b/client/ayon_aftereffects/api/webserver.py
@@ -24,12 +24,7 @@ log = logging.getLogger(__name__)
 
 
 class WebServerTool:
-    """
-        Basic POC implementation of asychronic websocket RPC server.
-        Uses class in external_app_1.py to mimic implementation for single
-        external application.
-        'test_client' folder contains two test implementations of client
-    """
+    """Basic asynchronous websocket RPC server."""
     _instance = None
 
     def __init__(self):
@@ -57,6 +52,10 @@ class WebServerTool:
         # add route with multiple methods for single "external app"
         self.webserver_thread = WebServerThread(self, self.port)
 
+    def get_websocket_url(self):
+        """Return websocket URL for the server from the host name and port."""
+        return f"ws://{self.host_name}:{self.port}/ws/"
+
     def add_route(self, *args, **kwargs):
         self.app.router.add_route(*args, **kwargs)
 
@@ -78,7 +77,7 @@ class WebServerTool:
             but one already running, without
             this publish would point to old context.
         """
-        client = WSRPCClient(os.getenv("WEBSOCKET_URL"),
+        client = WSRPCClient(self.get_websocket_url(),
                              loop=asyncio.get_event_loop())
         await client.connect()
 


### PR DESCRIPTION
## Changelog Description

Find a free available port for the websocket server on launch so that multiple After Effects instances can be launched at the same time.

## Additional review information

To launch After Effects in a way that it can open multiple instances, add the `-m` argument to the arguments in Application settings.

![image](https://github.com/user-attachments/assets/02e631a5-9c8a-4bc1-a34e-27888badaf99)

## Testing notes:

1. With the `-m` argument added in settings you can now launch multiple After Effects instances at same time.
2. Each will get a unique websocket URL port number, the tools should apply to ONLY that instance. 
3. (there should be no cross-communcation between the tools) 
