### PR TITLE
use data['workfile_startup'] for workfile tool

### DIFF
--- a/client/ayon_aftereffects/api/launch_logic.py
+++ b/client/ayon_aftereffects/api/launch_logic.py
@@ -52,7 +52,7 @@ def main(*subprocess_args):
         # Backwards compatibility
         os.getenv("AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH", True)
     )
-    workfiles_on_launch = env_value_to_bool(env_workfiles_on_launch)
+    workfiles_on_launch = env_value_to_bool(value=env_workfiles_on_launch)
 
     if is_in_tests():
         manager = AddonsManager()

--- a/client/ayon_aftereffects/api/launch_logic.py
+++ b/client/ayon_aftereffects/api/launch_logic.py
@@ -14,7 +14,7 @@ from wsrpc_aiohttp import (
 
 from qtpy import QtCore
 
-from ayon_core.lib import Logger, is_in_tests
+from ayon_core.lib import Logger, is_in_tests, env_value_to_bool
 from ayon_core.pipeline import install_host
 from ayon_core.addon import AddonsManager
 from ayon_core.tools.utils import host_tools, get_ayon_qt_app
@@ -47,11 +47,12 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
-    workfiles_on_launch = os.getenv(
+    env_workfiles_on_launch = os.getenv(
         "AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH",
         # Backwards compatibility
         os.getenv("AVALON_AFTEREFFECTS_WORKFILES_ON_LAUNCH", True)
     )
+    workfiles_on_launch = env_value_to_bool(env_workfiles_on_launch)
 
     if is_in_tests():
         manager = AddonsManager()

--- a/client/ayon_aftereffects/hooks/pre_launch_args.py
+++ b/client/ayon_aftereffects/hooks/pre_launch_args.py
@@ -79,7 +79,7 @@ class AEPrelaunchHook(PreLaunchHook):
 
         workfile_startup = self.data.get("workfile_startup", False)
         # set the env variable AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH to "true" or "false"
-        os.environ["AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
+        self.launch_context.env["AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
 
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)

--- a/client/ayon_aftereffects/hooks/pre_launch_args.py
+++ b/client/ayon_aftereffects/hooks/pre_launch_args.py
@@ -77,6 +77,10 @@ class AEPrelaunchHook(PreLaunchHook):
         ):
             new_launch_args.append(workfile_path)
 
+        workfile_startup = self.data.get("workfile_startup", False)
+        # set the env variable AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH to "true" or "false"
+        os.environ["AYON_AFTEREFFECTS_WORKFILES_ON_LAUNCH"] = str(workfile_startup).lower()
+
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)
 


### PR DESCRIPTION
## Changelog Description
This pull request is with regards to this issue report https://github.com/ynput/ayon-aftereffects/issues/34

## Additional review information
Use self.data.get("workfile_startup", False) to determine if the workfile tool should be opened on startup

## Testing notes:
1. start with this step
use ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup to setup whether to open workfile tool should be opened or not

2. start the tool
