### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_aftereffects/plugins/create/workfile_creator.py
+++ b/client/ayon_aftereffects/plugins/create/workfile_creator.py
@@ -1,5 +1,3 @@
-import ayon_api
-
 from ayon_core.pipeline import (
     AutoCreator,
     CreatedInstance


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
