### PR TITLE
add ae to hosts in collect_workfile

### DIFF
--- a/client/ayon_aftereffects/plugins/publish/collect_workfile.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_workfile.py
@@ -9,6 +9,7 @@ class CollectWorkfile(pyblish.api.InstancePlugin):
     label = "Collect After Effects Workfile"
     order = pyblish.api.CollectorOrder + 0.1
     families = ["workfile"]
+    hosts = ["aftereffects"]
 
     def process(self, instance):
         current_file = instance.context.data["currentFile"]


### PR DESCRIPTION
## Changelog Description
Add hosts `hosts = ["aftereffects"]` to client/ayon_aftereffects/plugins/publish/collect_workfile.py
To ensure that this is only run in after effect context. 

## Additional review information
At the moment `collect_workfile` might behave unexpectedly and run on other processes. Need to specify that this plugin is run in the context of AE only. 

## Testing notes:
1. Start Publish outisde of ae using an addon of type `IPluginPaths` 
2. Make sure that the .ae representation is not added to a `workfile` repre.
