### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -22,6 +22,7 @@ class RenderCreator(Creator):
     identifier = "render"
     label = "Render"
     product_type = "render"
+    product_base_type = "render"
     description = "Render creator"
     icon = "eye"
 

--- a/client/ayon_aftereffects/plugins/create/workfile_creator.py
+++ b/client/ayon_aftereffects/plugins/create/workfile_creator.py
@@ -9,6 +9,7 @@ from ayon_aftereffects.api.pipeline import cache_and_get_instances
 class AEWorkfileCreator(AutoCreator):
     identifier = "workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
 
     default_variant = "Main"
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.