### PR TITLE
Chore: Product name signatures

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -260,7 +260,9 @@ class RenderCreator(Creator):
         task_entity,
         variant,
         host_name,
-        instance
+        instance=None,
+        project_entity=None,
+        product_type=None,
     ):
         dynamic_data = {}
         if instance is not None:

--- a/client/ayon_aftereffects/plugins/create/workfile_creator.py
+++ b/client/ayon_aftereffects/plugins/create/workfile_creator.py
@@ -64,14 +64,6 @@ class AEWorkfileCreator(AutoCreator):
                 "task": task_name,
                 "variant": self.default_variant,
             }
-            data.update(self.get_dynamic_data(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
-                None,
-            ))
 
             new_instance = CreatedInstance(
                 self.product_type, product_name, data, self


### PR DESCRIPTION
## Changelog Description
Add `product_type` to `get_dynamic_data`.

## Additional review information
Method `get_product_name` now can expect and work with product type.

Also removed usage of `get_dynamic_data` from workfile create plugin.

## Testing notes:
AE can work with last ayon-core release and with [this PR](https://github.com/ynput/ayon-core/pull/1656).
1. Use last ayon-core release and ayon-tvpaint from this PR.
2. Open a workfile.
3. Create an instance.
4. Change ayon-core to use https://github.com/ynput/ayon-core/pull/1656 .
5. Open the same workfile.
6. The instance should be available.
7. You can create new instance.