### PR TITLE
Chore: Initial product base type usage

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -99,7 +99,10 @@ class RenderCreator(Creator):
                 data["orig_comp_name"] = composition_name
 
             new_instance = CreatedInstance(
-                self.product_type, comp_product_name, data, self
+                self.product_base_type,
+                comp_product_name,
+                data,
+                self
             )
 
             api.get_stub().imprint(new_instance.id,
@@ -166,13 +169,14 @@ class RenderCreator(Creator):
 
     def collect_instances(self):
         for instance_data in cache_and_get_instances(self):
-            # legacy instances have product_type=='render' or 'renderLocal', use them
             creator_id = instance_data.get("creator_identifier")
             if not creator_id:
                 # NOTE this is for backwards compatibility but probably can be
                 #   removed
-                creator_id = instance_data.get("family", "")
-                creator_id = creator_id.replace("Local", "")
+                # - legacy family was 'render' or 'renderLocal'
+                family = instance_data.get("family", "").replace("Local", "")
+                if family == self.product_base_type:
+                    creator_id = self.identifier
 
             if creator_id == self.identifier:
                 instance_data = self._handle_legacy(instance_data)
@@ -290,7 +294,8 @@ class RenderCreator(Creator):
         if not instance_data.get("creator_attributes"):
             is_old_farm = instance_data.get("family") != "renderLocal"
             instance_data["creator_attributes"] = {"farm": is_old_farm}
-            instance_data["productType"] = self.product_type
+            instance_data["productBaseType"] = self.product_base_type
+            instance_data["productType"] = self.product_base_type
 
         if instance_data["creator_attributes"].get("mark_for_review") is None:
             instance_data["creator_attributes"]["mark_for_review"] = True

--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -106,10 +106,10 @@ class CollectAERender(publish.AbstractCollectRender):
                 instance_families.append(product_base_type)
             product_name = inst.data["productName"]
 
-            kwargs = {
-                "productType": product_type,
-                "productBaseType": product_base_type,
-            }
+            kwargs = dict(
+                productType=product_type,
+                productBaseType=product_base_type,
+            )
             if "productBaseType" not in attr.fields_dict(AERenderInstance):
                 kwargs["productType"] = kwargs.pop("productBaseType")
 

--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -69,8 +69,11 @@ class CollectAERender(publish.AbstractCollectRender):
             if not inst.data.get("active", True):
                 continue
 
+            product_base_type = inst.data.get("productBaseType")
             product_type = inst.data["productType"]
-            if product_type not in ["render", "renderLocal"]:  # legacy
+            if not product_base_type:
+                product_base_type = product_type
+            if product_base_type not in ["render", "renderLocal"]:
                 continue
 
             comp_id = int(inst.data["members"][0])
@@ -98,18 +101,26 @@ class CollectAERender(publish.AbstractCollectRender):
                     "No file extension set in Render Queue")
             render_item = render_q[0]
 
-            product_type = "render"
             instance_families = inst.data.get("families", [])
-            instance_families.append(product_type)
+            if product_base_type not in instance_families:
+                instance_families.append(product_base_type)
             product_name = inst.data["productName"]
+
+            kwargs = {
+                "productType": product_type,
+                "productBaseType": product_base_type,
+            }
+            if "productBaseType" not in attr.fields_dict(AERenderInstance):
+                kwargs["productType"] = kwargs.pop("productBaseType")
+
             instance = AERenderInstance(
-                productType=product_type,
-                family=product_type,
+                **kwargs,
+                family=product_base_type,
                 families=instance_families,
                 version=version,
                 time="",
                 source=current_file,
-                label="{} - {}".format(product_name, product_type),
+                label=f"{product_name} - {product_base_type}",
                 productName=product_name,
                 folderPath=inst.data["folderPath"],
                 task=task_name,

--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -73,7 +73,7 @@ class CollectAERender(publish.AbstractCollectRender):
             product_type = inst.data["productType"]
             if not product_base_type:
                 product_base_type = product_type
-            if product_base_type not in ["render", "renderLocal"]:
+            if product_base_type != "render":
                 continue
 
             comp_id = int(inst.data["members"][0])

--- a/client/ayon_aftereffects/plugins/publish/extract_local_render.py
+++ b/client/ayon_aftereffects/plugins/publish/extract_local_render.py
@@ -10,7 +10,7 @@ class ExtractLocalRender(publish.Extractor):
     order = publish.Extractor.order - 0.47
     label = "Extract Local Render"
     hosts = ["aftereffects"]
-    families = ["renderLocal", "render.local"]
+    families = ["render.local"]
 
     def process(self, instance):
         stub = get_stub()


### PR DESCRIPTION
## Changelog Description
Use product base type in the create and publish logic.

## Additional review information
This PR was opened because of change in `RenderInstance` (affecting `AERenderInstance`) where `productBaseType` was added ([core PR](https://github.com/ynput/ayon-core/pull/1687)). With that I've added more changes that can be applied now without any harm.

## Testing notes:
1. Render logic still works as expected. Instances are collected, can be created and can be publisher.
