### PR TITLE
Load workfiles into an open AEP project

### DIFF
--- a/client/ayon_aftereffects/plugins/load/load_file.py
+++ b/client/ayon_aftereffects/plugins/load/load_file.py
@@ -19,6 +19,7 @@ class FileLoader(api.AfterEffectsLoader):
         "prerender",
         "review",
         "audio",
+        "workfile",
     }
     representations = {"*"}
 

--- a/client/ayon_aftereffects/plugins/load/load_file.py
+++ b/client/ayon_aftereffects/plugins/load/load_file.py
@@ -6,7 +6,7 @@ from ayon_aftereffects import api
 
 
 class FileLoader(api.AfterEffectsLoader):
-    """Load images
+    """Load images and full AE workfiles.
 
     Stores the imported product version in a container named after the folder.
     """


### PR DESCRIPTION
## Changelog Description

This pull request introduces the functionality to load workfiles within an already open Adobe After Effects (AEP) workfile.

## Additional Review Information

The behavior aligns with the « File > Import > File… » command available in After Effects. The intended output is an `.aep` workfile that is successfully loaded within the tree of an open After Effects project.

## Discussion

The `workfile` product type may be overly broad. The sole concern I identify is attempting to force AE to load an incompatible workfile type, which could potentially cause the application to crash.

I have attempted to load a `.hip` workfile to ascertain if such a crash would occur, but After Effects appears to prevent the loading of incompatible file types. However, further testing is required to validate this assertion. I am receptive to suggestions for enhancing this pull request.

## Testing notes:

Windows:

<img width="310" height="137" alt="Original project tree" src="https://github.com/user-attachments/assets/a0a05f70-d174-440d-aafc-7a3c840e45d6" />

Original project tree
1. Window > Extensions > AYON
2. Load
3. Right click on an .aep workfile
4. Load file (aep)
<img width="511" height="281" alt="Capture d’écran 2026-02-25 à 14 59 46" src="https://github.com/user-attachments/assets/b2eeb67e-da2d-401b-94e8-86763247bf86" />

5. Workfile loaded in project tree
<img width="313" height="220" alt="Capture d’écran 2026-02-25 à 15 00 24" src="https://github.com/user-attachments/assets/5c8bbb27-0b2c-496f-9315-6731256e2dba" />
