### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -8,6 +8,7 @@ from ayon_core.pipeline import (
 )
 from ayon_core.lib import prepare_template_data
 from ayon_core.pipeline.create import PRODUCT_NAME_ALLOWED_SYMBOLS
+
 from ayon_aftereffects import api
 from ayon_aftereffects.api.pipeline import cache_and_get_instances
 from ayon_aftereffects.api.lib import set_settings
@@ -21,10 +22,11 @@ class RenderCreator(Creator):
     """
     identifier = "render"
     label = "Render"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     description = "Render creator"
     icon = "eye"
+    settings_category = "aftereffects"
 
     create_allow_context_change = True
 
@@ -98,11 +100,15 @@ class RenderCreator(Creator):
             if self.rename_comp_to_product_name:
                 data["orig_comp_name"] = composition_name
 
+            product_type = data.get("productType")
+            if not product_type:
+                product_type = self.product_base_type
             new_instance = CreatedInstance(
-                self.product_base_type,
-                comp_product_name,
-                data,
-                self
+                product_base_type=self.product_base_type,
+                product_type=product_type,
+                product_name=comp_product_name,
+                data=data,
+                creator=self,
             )
 
             api.get_stub().imprint(new_instance.id,

--- a/client/ayon_aftereffects/plugins/create/create_render.py
+++ b/client/ayon_aftereffects/plugins/create/create_render.py
@@ -218,23 +218,6 @@ class RenderCreator(Creator):
                     api.get_stub().rename_item(comp_id,
                                                new_comp_name)
 
-    def apply_settings(self, project_settings):
-        plugin_settings = (
-            project_settings["aftereffects"]["create"]["RenderCreator"]
-        )
-
-        self.mark_for_review = plugin_settings["mark_for_review"]
-        self.default_variants = plugin_settings.get(
-            "default_variants",
-            plugin_settings.get("defaults") or []
-        )
-        self.rename_comp_to_product_name = plugin_settings.get(
-            "rename_comp_to_product_name", self.rename_comp_to_product_name
-        )
-        self.force_setting_values = plugin_settings.get(
-            "force_setting_values", self.force_setting_values
-        )
-
     def get_detail_description(self):
         return """Creator for Render instances
 

--- a/client/ayon_aftereffects/plugins/create/workfile_creator.py
+++ b/client/ayon_aftereffects/plugins/create/workfile_creator.py
@@ -37,7 +37,7 @@ class AEWorkfileCreator(AutoCreator):
     def create(self, options=None):
         existing_instance = None
         for instance in self.create_context.instances:
-            if instance.product_type == self.product_type:
+            if instance.creator_identifier == self.identifier:
                 existing_instance = instance
                 break
 

--- a/client/ayon_aftereffects/plugins/create/workfile_creator.py
+++ b/client/ayon_aftereffects/plugins/create/workfile_creator.py
@@ -8,8 +8,8 @@ from ayon_aftereffects.api.pipeline import cache_and_get_instances
 
 class AEWorkfileCreator(AutoCreator):
     identifier = "workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
 
     default_variant = "Main"
 
@@ -22,7 +22,11 @@ class AEWorkfileCreator(AutoCreator):
             if creator_id == self.identifier:
                 product_name = instance_data["productName"]
                 instance = CreatedInstance(
-                    self.product_type, product_name, instance_data, self
+                    product_base_type=self.product_base_type,
+                    product_type=self.product_base_type,
+                    product_name=product_name,
+                    data=instance_data,
+                    creator=self,
                 )
                 self._add_instance_to_context(instance)
 
@@ -66,7 +70,11 @@ class AEWorkfileCreator(AutoCreator):
             }
 
             new_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_base_type=self.product_base_type,
+                product_type=self.product_base_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
             )
             self._add_instance_to_context(new_instance)
 

--- a/client/ayon_aftereffects/plugins/load/load_background.py
+++ b/client/ayon_aftereffects/plugins/load/load_background.py
@@ -8,7 +8,7 @@ from ayon_aftereffects.api.lib import get_background_layers
 
 class BackgroundLoader(api.AfterEffectsLoader):
     """
-        Load images from Background product type
+        Load images from Background product base type
         Creates for each background separate folder with all imported images
         from background json AND automatically created composition with layers,
         each layer for separate image.
@@ -17,7 +17,8 @@ class BackgroundLoader(api.AfterEffectsLoader):
         metadata
     """
     label = "Load JSON Background"
-    product_types = {"background"}
+    product_base_types = {"background"}
+    product_types = product_base_types
     representations = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_aftereffects/plugins/load/load_file.py
+++ b/client/ayon_aftereffects/plugins/load/load_file.py
@@ -12,7 +12,7 @@ class FileLoader(api.AfterEffectsLoader):
     """
     label = "Load file"
 
-    product_types = {
+    product_base_types = {
         "image",
         "plate",
         "render",
@@ -20,6 +20,7 @@ class FileLoader(api.AfterEffectsLoader):
         "review",
         "audio",
     }
+    product_types = product_base_types
     representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_aftereffects/plugins/publish/collect_render.py
+++ b/client/ayon_aftereffects/plugins/publish/collect_render.py
@@ -106,15 +106,9 @@ class CollectAERender(publish.AbstractCollectRender):
                 instance_families.append(product_base_type)
             product_name = inst.data["productName"]
 
-            kwargs = dict(
+            instance = AERenderInstance(
                 productType=product_type,
                 productBaseType=product_base_type,
-            )
-            if "productBaseType" not in attr.fields_dict(AERenderInstance):
-                kwargs["productType"] = kwargs.pop("productBaseType")
-
-            instance = AERenderInstance(
-                **kwargs,
                 family=product_base_type,
                 families=instance_families,
                 version=version,

--- a/package.py
+++ b/package.py
@@ -7,6 +7,8 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">0.3.2",
+    "core": ">=1.8.0",
 }
-ayon_compatible_addons = {}
+ayon_compatible_addons = {
+    "deadline": ">=0.7.0",
+}

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,6 +1,18 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
 class CreateRenderPlugin(BaseSettingsModel):
     mark_for_review: bool = SettingsField(True, title="Review")
     default_variants: list[str] = SettingsField(
@@ -15,6 +27,13 @@ class CreateRenderPlugin(BaseSettingsModel):
         description=(
             "Rename composition to product name when creating render instance "
             "or when updating product name, e.g. on variant change."
+        )
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
         )
     )
 


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
All create plugins do have product base type as main "pipeline" type. Also added product type as an alias for render create plugin.

## Testing notes:
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Define product types for render create plugin.
3. Create an instance with the product type.
4. Product name should use the product type in name (if template defines that).
5. Publish the instance.
6. Loader tool should show the product type and product base type in UI.