### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_aftereffects/plugins/load/load_background.py
+++ b/client/ayon_aftereffects/plugins/load/load_background.py
@@ -19,7 +19,8 @@ class BackgroundLoader(api.AfterEffectsLoader):
     label = "Load JSON Background"
     product_base_types = {"background"}
     product_types = product_base_types
-    representations = {"json"}
+    representations = {"*"}
+    extensions = {"json"}
 
     def load(self, context, name=None, namespace=None, data=None):
         stub = self.get_stub()


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.